### PR TITLE
ci: stop auto-committing bundled scripts

### DIFF
--- a/.github/workflows/bundle.yaml
+++ b/.github/workflows/bundle.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   bundle:
@@ -40,16 +40,3 @@ jobs:
 
       - name: Build dist
         run: pnpm build
-
-      - name: Commit generated dist
-        shell: bash
-        run: |
-          if [ -z "$(git status --porcelain -- test-dist pnpm-lock.yaml)" ]; then
-            echo "dist is already up to date"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add test-dist pnpm-lock.yaml
-          git commit -m "chore: bundle TavernHelper scripts"
-          git push origin "HEAD:${GITHUB_REF_NAME}"


### PR DESCRIPTION
Removes the GitHub Actions self-commit/push step from the TavernHelper bundle workflow.\n\nChanges:\n- downgrade workflow token permission from contents: write to contents: read\n- keep pnpm install + pnpm build verification\n- remove generated-dist git add/commit/push\n\nVerified:\n- local pnpm build passes\n- workflow passes on the task branch\n- same change is live and passing on origin/staging and origin/release/2.0.15\n- no Cloudflare deployment or production change